### PR TITLE
fix(deps): allow symfony/http-client 7.x for PHP 8.2/8.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^12.0",
         "rector/rector": "^2.0",
-        "symfony/http-client": "^8.0"
+        "symfony/http-client": "^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
symfony/http-client v8 requires PHP 8.4+, but this package supports PHP 8.2+.

## Problem
Recent renovate PRs upgraded symfony/http-client to ^8.0, which broke CI for PHP 8.2 and 8.3 builds since v8 requires PHP >=8.4.

## Solution
Allow both v7 and v8: `^7.0 || ^8.0`
- PHP 8.2/8.3: uses symfony/http-client v7.x
- PHP 8.4: uses symfony/http-client v8.x

## Additional recommendation
Branch protection should require CI build checks to pass, not just CodeQL. Currently only 'Analyze (actions)' is required.