### PR TITLE
fix: downgrade to PHPUnit 11 and allow Symfony HTTP Client 7 for compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,9 +55,9 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
-        "phpunit/phpunit": "^12.0",
+        "phpunit/phpunit": "^11.0",
         "rector/rector": "^2.0",
-        "symfony/http-client": "^8.0"
+        "symfony/http-client": "^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary

Fixes CI failures on all PHP versions by:
- Downgrading to PHPUnit 11 (which supports @test annotations)
- Allowing Symfony HTTP Client 7 for PHP 8.2 compatibility

## Problem

The CI matrix tests PHP 8.2, 8.3, and 8.4, but recent dependency updates caused multiple issues:

1. **PHP 8.2 composer install failure:**
   - `phpunit/phpunit: ^12.0` requires PHP >=8.3
   - `symfony/http-client: ^8.0` requires PHP >=8.4

2. **PHP 8.3/8.4 test execution failure:**
   - PHPUnit 12 removed support for `@test` annotations
   - All test files use `@test` annotations instead of `#[Test]` attributes or `testMethodName()` naming
   - PHPUnit 12 reports "No tests executed!" and fails

## Solution

Changed require-dev constraints:
```json
"phpunit/phpunit": "^11.0"  // was ^12.0
"symfony/http-client": "^7.0 || ^8.0"  // was ^8.0
```

This allows:
- **PHP 8.2:** PHPUnit 11.x + Symfony HTTP Client 7.x
- **PHP 8.3:** PHPUnit 11.x + Symfony HTTP Client 7.x/8.x  
- **PHP 8.4:** PHPUnit 11.x + Symfony HTTP Client 7.x/8.x

PHPUnit 11 supports:
- PHP 8.2+ ✅
- `@test` annotations ✅ (removed in PHPUnit 12)
- All current test patterns ✅

## Test Plan

- [ ] CI passes on PHP 8.2 (composer install succeeds, all tests pass)
- [ ] CI passes on PHP 8.3 (all checks pass with PHPUnit 11)
- [ ] CI passes on PHP 8.4 (all checks pass with PHPUnit 11)

## Related PRs

Supersedes #14 (which only fixed symfony/http-client)

## Note on PR #15

PR #15 wants to upgrade `magicsunday/jsonmapper` to ^3.0.0, which requires PHP 8.3+. After this PR is merged, there should be a separate discussion about either:
- Dropping PHP 8.2 from the CI matrix, OR
- Keeping jsonmapper at ^2.4.0 for PHP 8.2 compatibility

## Migration to PHPUnit 12

To use PHPUnit 12 in the future, tests would need refactoring:
- Replace `@test` annotations with `#[Test]` attributes, OR
- Rename test methods to start with `test` prefix (e.g., `testEventFile()`)