### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
         steps:
             -   id: checkout
                 name: Checkout
-                uses: actions/checkout@v6
+                uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             -   id: setup_php
                 name: Set up PHP version ${{ matrix.php }}
-                uses: shivammathur/setup-php@v2
+                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
                 with:
                     php-version: ${{ matrix.php }}
                     tools: composer:v2, php-cs-fixer
@@ -36,7 +36,7 @@ jobs:
 
             -   id: composer-cache-dependencies
                 name: Cache Composer dependencies
-                uses: actions/cache@v6
+                uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
                 with:
                     path: ${{ steps.composer-cache-vars.outputs.dir }}
                     key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ steps.composer-cache-vars.outputs.timestamp }}

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>netresearch/renovate-config",
+    "helpers:pinGitHubActionDigests",
     ":automergeMinor",
     ":automergePatch"
   ],


### PR DESCRIPTION
## Problem

Every CI run was failing within seconds at `Set up job` with:

> The actions `actions/checkout@v6`, `shivammathur/setup-php@v2`, and `actions/cache@v6` are not allowed in netresearch/sdk-api-universal-messenger because all actions must be pinned to a full-length commit SHA.

The repository ruleset enforces SHA-pinned actions, but `.github/workflows/ci.yml` referenced version tags, so the workflow never reached a single step.

## Fix

Pin all three actions in `ci.yml` to full-length commit SHAs (latest stable, with version comment):

| Action | Was | Now |
|---|---|---|
| actions/checkout | `@v6` | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` # v7.0.0 |
| shivammathur/setup-php | `@v2` | `f3e473d116dcccaddc5834248c87452386958240` # 2.37.2 |
| actions/cache | `@v6` | `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` # v6.1.0 |

Also add the `helpers:pinGitHubActionDigests` Renovate preset so future action updates keep SHA pins (with version comment) instead of reintroducing tags — which is what produced the recent failing Renovate PRs (#23, #24).

## Verification

`renovate.json` validates as JSON; `actionlint` reports only the pre-existing SC2086 info notes (untouched). CI on this branch is the real proof — it should now pass setup-job and run the matrix.