### PR TITLE
PHP 8.5 support: native xmlmapper attributes + 8.2–8.5 tooling (#21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '8.2', '8.3', '8.4' ]
+                php: [ '8.2', '8.3', '8.4', '8.5' ]
 
         steps:
             -   id: checkout

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,8 @@
         "platform-check": false,
         "allow-plugins": {
             "php-http/discovery": false
+        },
+        "platform": {
         }
     },
     "require": {
@@ -31,7 +33,7 @@
         "ext-simplexml": "*",
         "ext-xmlwriter": "*",
         "magicsunday/jsonmapper": "^2.4.0",
-        "magicsunday/xmlmapper": "^2.0 || ^3.0",
+        "magicsunday/xmlmapper": "^2.0 || ^3.0.1",
         "php-http/discovery": "^1.19.0",
         "php-http/httplug": "^2.4.0",
         "php-http/logger-plugin": "^1.3.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-simplexml": "*",
         "ext-xmlwriter": "*",
         "magicsunday/jsonmapper": "^2.4.0",
-        "magicsunday/xmlmapper": "^1.0.0",
+        "magicsunday/xmlmapper": "^2.0 || ^3.0",
         "php-http/discovery": "^1.19.0",
         "php-http/httplug": "^2.4.0",
         "php-http/logger-plugin": "^1.3.0",

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.1.x-dev"
+            "dev-main": "2.0.x-dev"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-simplexml": "*",
         "ext-xmlwriter": "*",
         "magicsunday/jsonmapper": "^2.4.0",
-        "magicsunday/xmlmapper": "^2.0 || ^3.0.1",
+        "magicsunday/xmlmapper": "^2.0 || ^3.0",
         "php-http/discovery": "^1.19.0",
         "php-http/httplug": "^2.4.0",
         "php-http/logger-plugin": "^1.3.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,11 @@ parameters:
     # You can currently choose from 10 levels (0 is the loosest and 9 is the strictest).
     level: 8
 
+    # Statically verify the whole supported PHP range (8.2 - 8.5).
+    phpVersion:
+        min: 80200
+        max: 80500
+
     paths:
         - %currentWorkingDirectory%/src/
 

--- a/src/Model/Collection/AbstractCollection.php
+++ b/src/Model/Collection/AbstractCollection.php
@@ -135,8 +135,6 @@ abstract class AbstractCollection implements CollectionInterface, JsonSerializab
 
     /**
      * Return the key of the current element.
-     *
-     * @return int|string|null
      */
     public function key(): int|string|null
     {

--- a/src/Request/Event.php
+++ b/src/Request/Event.php
@@ -29,18 +29,16 @@ class Event implements RequestInterface
      * Optional unique identifier (if no ID is specified, a random ID will be generated).
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $id = null;
 
     /**
      * Optional specification of a newsletter series to which the newsletter should be assigned.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $newsletterGroup = null;
 
     /**
@@ -48,9 +46,8 @@ class Event implements RequestInterface
      * with the same event ID in the archive.
      *
      * @var bool|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?bool $skipUsedIDs = null;
 
     /**
@@ -60,36 +57,32 @@ class Event implements RequestInterface
      * Set to FALSE if skipped newsletters (skipedUsedIDs = "true") should not be saved in the newsletter archive.
      *
      * @var bool|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?bool $archiveSkipped = null;
 
     /**
      * FALSE if the newsletter should not be saved in the archive.
      *
      * @var bool|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?bool $archive = null;
 
     /**
      * Optional indication of the username of the user who triggered the newsletter dispatch.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $createdBy = null;
 
     /**
      * Optional indication of the display username, the user who triggered the newsletter dispatch.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $createdByDisplayName = null;
 
     /**

--- a/src/Request/Event.php
+++ b/src/Request/Event.php
@@ -117,11 +117,8 @@ class Event implements RequestInterface
     //     * @var null|PreExec
     //     */
     //    private ?PreExec $preExec = null;
-
     /**
      * @param string|null $id
-     *
-     * @return Event
      */
     public function setId(?string $id): Event
     {
@@ -132,8 +129,6 @@ class Event implements RequestInterface
 
     /**
      * @param string|null $newsletterGroup
-     *
-     * @return Event
      */
     public function setNewsletterGroup(?string $newsletterGroup): Event
     {
@@ -144,8 +139,6 @@ class Event implements RequestInterface
 
     /**
      * @param bool|null $skipUsedIDs
-     *
-     * @return Event
      */
     public function setSkipUsedIDs(?bool $skipUsedIDs): Event
     {
@@ -156,8 +149,6 @@ class Event implements RequestInterface
 
     /**
      * @param bool|null $archiveSkipped
-     *
-     * @return Event
      */
     public function setArchiveSkipped(?bool $archiveSkipped): Event
     {
@@ -168,8 +159,6 @@ class Event implements RequestInterface
 
     /**
      * @param bool|null $archive
-     *
-     * @return Event
      */
     public function setArchive(?bool $archive): Event
     {
@@ -180,8 +169,6 @@ class Event implements RequestInterface
 
     /**
      * @param string|null $createdBy
-     *
-     * @return Event
      */
     public function setCreatedBy(?string $createdBy): Event
     {
@@ -192,8 +179,6 @@ class Event implements RequestInterface
 
     /**
      * @param string|null $createdByDisplayName
-     *
-     * @return Event
      */
     public function setCreatedByDisplayName(?string $createdByDisplayName): Event
     {
@@ -204,8 +189,6 @@ class Event implements RequestInterface
 
     /**
      * @param Destination|null $destination
-     *
-     * @return Event
      */
     public function setDestination(?Destination $destination): Event
     {
@@ -216,8 +199,6 @@ class Event implements RequestInterface
 
     /**
      * @param Data|null $data
-     *
-     * @return Event
      */
     public function setData(?Data $data): Event
     {
@@ -228,8 +209,6 @@ class Event implements RequestInterface
 
     /**
      * @param Date|null $date
-     *
-     * @return Event
      */
     public function setDate(?Date $date): Event
     {
@@ -240,8 +219,6 @@ class Event implements RequestInterface
 
     /**
      * @param string[] $tags
-     *
-     * @return Event
      */
     public function setTags(array $tags): Event
     {
@@ -252,8 +229,6 @@ class Event implements RequestInterface
 
     /**
      * @param string $tag
-     *
-     * @return Event
      */
     public function addTag(string $tag): Event
     {

--- a/src/Request/Event/Data.php
+++ b/src/Request/Event/Data.php
@@ -30,9 +30,8 @@ class Data implements XmlSerializable
      * This information is only necessary if the standard email address is to be changed.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $mailto = null;
 
     /**

--- a/src/Request/Event/Data/Email.php
+++ b/src/Request/Event/Data/Email.php
@@ -31,9 +31,8 @@ class Email implements XmlSerializable
      * (make sure the email address format is correct: "John Doe <john.doe@example.org>").
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $sender = null;
 
     /**
@@ -41,9 +40,8 @@ class Email implements XmlSerializable
      * (make sure the email address format is correct: "John Doe <john.doe@example.org>").
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $replyto = null;
 
     /**
@@ -51,18 +49,16 @@ class Email implements XmlSerializable
      * (make sure the email address format is correct: "John Doe <john.doe@example.org>").
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $envelopeFrom = null;
 
     /**
      * TRUE if the HTML email should only be sent to subscribers with the "html" attribute set.
      *
      * @var bool|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?bool $obeyPreferHtml = null;
 
     /**
@@ -71,18 +67,16 @@ class Email implements XmlSerializable
      * If FALSE, only the HTML email is sent.
      *
      * @var bool|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?bool $sendBothParts = null;
 
     /**
      * URL that precedes the relative links.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $baseUrl = null;
 
     /**
@@ -90,9 +84,8 @@ class Email implements XmlSerializable
      * then the baseUrl attribute from the email element is used instead.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $downloadUrl = null;
 
     /**
@@ -101,9 +94,8 @@ class Email implements XmlSerializable
      * However, the "mixed" mode can only be selected here if the "mixed" mode is also set globally.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $trackingMode = null;
 
     /**

--- a/src/Request/Event/Data/Email/File.php
+++ b/src/Request/Event/Data/Email/File.php
@@ -29,32 +29,28 @@ class File implements XmlSerializable
      * which can be referenced in the email using "cid:content-name".
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $name = null;
 
     /**
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $disposition = null;
 
     /**
      * @var bool|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?bool $inline = null;
 
     /**
      * The base64 encoded file content.
      *
      * @var string|null
-     *
-     * @XmlNodeValue
      */
+    #[XmlNodeValue]
     private ?string $content = null;
 
     /**

--- a/src/Request/Event/Data/Email/HtmlText.php
+++ b/src/Request/Event/Data/Email/HtmlText.php
@@ -35,18 +35,16 @@ class HtmlText implements XmlSerializable
      * absolute path "none" if there is no HTML e-mail Email should be sent.
      *
      * @var bool|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?bool $inline = null;
 
     /**
      * Specification of the encoding.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $charset = null;
 
     /**
@@ -57,18 +55,16 @@ class HtmlText implements XmlSerializable
      * none   - if no images are to be embedded.
      *
      * @var string
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private string $embedImages = 'byPath';
 
     /**
      * URL that precedes the relative links.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $baseUrl = null;
 
     /**
@@ -76,36 +72,32 @@ class HtmlText implements XmlSerializable
      * then the baseUrl attribute from the email element is used instead.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $downloadUrl = null;
 
     /**
      * FALSE if click tracking should be deactivated for this newsletter.
      *
      * @var bool|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?bool $linkTracking = null;
 
     /**
      * FALSE if tracking of opens for this newsletter should be deactivated.
      *
      * @var bool|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?bool $viewTracking = null;
 
     /**
      * Function name of a CSE callback to be called when the newsletter is rendered.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $renderCallback = null;
 
     /**
@@ -118,18 +110,16 @@ class HtmlText implements XmlSerializable
      * newsletters can open older newsletters without the referenced files no longer being available.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $restProxyUrl = null;
 
     /**
      * The HTML text to send.
      *
      * @var string|null
-     *
-     * @XmlCDataSection
      */
+    #[XmlCDataSection]
     private ?string $content = null;
 
     /**

--- a/src/Request/Event/Data/Email/PlainText.php
+++ b/src/Request/Event/Data/Email/PlainText.php
@@ -31,27 +31,24 @@ class PlainText implements XmlSerializable
      * "none" if no text email is to be sent.
      *
      * @var bool|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?bool $inline = null;
 
     /**
      * Specification of the encoding.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $charset = null;
 
     /**
      * URL that precedes the relative links.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $baseUrl = null;
 
     /**
@@ -59,36 +56,32 @@ class PlainText implements XmlSerializable
      * then the baseUrl attribute from the email element is used instead.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $downloadUrl = null;
 
     /**
      * FALSE if click tracking should be deactivated for this newsletter.
      *
      * @var bool|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?bool $linkTracking = null;
 
     /**
      * Function name of a CSE callback to be called when the newsletter is rendered.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $renderCallback = null;
 
     /**
      * The plain text to send.
      *
      * @var string|null
-     *
-     * @XmlNodeValue
      */
+    #[XmlNodeValue]
     private ?string $content = null;
 
     /**

--- a/src/Request/Event/Date.php
+++ b/src/Request/Event/Date.php
@@ -29,9 +29,8 @@ class Date implements XmlSerializable
      * The date/time value.
      *
      * @var string
-     *
-     * @XmlNodeValue
      */
+    #[XmlNodeValue]
     private readonly string $value;
 
     /**
@@ -39,9 +38,8 @@ class Date implements XmlSerializable
      * The default format is "dd.MM.yyyy HH:mm:ss".
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $format = null;
 
     /**

--- a/src/Request/Event/Destination/Preview.php
+++ b/src/Request/Event/Destination/Preview.php
@@ -28,9 +28,8 @@ class Preview implements XmlSerializable
      * Specification of the preview service. Currently only "litmus" is possible as a value.
      *
      * @var string
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private string $service = 'litmus';
 
     /**

--- a/src/Request/Event/Destination/Preview/BaseEntry.php
+++ b/src/Request/Event/Destination/Preview/BaseEntry.php
@@ -29,9 +29,8 @@ class BaseEntry implements XmlSerializable
      * uniquely identified to personalize the preview.
      *
      * @var string|null
-     *
-     * @XmlAttribute
      */
+    #[XmlAttribute]
     private ?string $email = null;
 
     /**

--- a/src/RequestBuilder/EventFile/CreateRequestBuilder.php
+++ b/src/RequestBuilder/EventFile/CreateRequestBuilder.php
@@ -341,8 +341,6 @@ class CreateRequestBuilder extends AbstractRequestBuilder
     /**
      * This method creates the actual request object and fills it with the data set in the request builder.
      *
-     * @return Event
-     *
      * @throws RequestValidatorException
      */
     public function create(): Event

--- a/src/Serializer/XmlSerializer.php
+++ b/src/Serializer/XmlSerializer.php
@@ -33,8 +33,6 @@ class XmlSerializer
      * Maps the given request type instance to XML.
      *
      * @param RequestInterface $instance
-     *
-     * @return string|false
      */
     public function encode(RequestInterface $instance): string|false
     {

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -45,8 +45,6 @@ class TestCase extends \PHPUnit\Framework\TestCase
      *
      * @param string $responseData
      * @param int    $statusCode
-     *
-     * @return UniversalMessenger|MockObject
      */
     public function getServiceFactoryMock(string $responseData = '', int $statusCode = 200): MockObject|UniversalMessenger
     {
@@ -187,7 +185,6 @@ class TestCase extends \PHPUnit\Framework\TestCase
      * Asserts that a variable is an instance of or null.
      *
      * @param string $expected
-     * @param mixed  $actual
      * @param string $message
      */
     public static function assertIsNullOrInstanceOf(string $expected, mixed $actual, string $message = ''): void
@@ -205,7 +202,6 @@ class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * Asserts that a variable is of type array or null.
      *
-     * @param mixed  $actual
      * @param string $message
      */
     public static function assertIsNullOrArray(mixed $actual, string $message = ''): void
@@ -223,7 +219,6 @@ class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * Asserts that a variable is of type bool or null.
      *
-     * @param mixed  $actual
      * @param string $message
      */
     public static function assertIsNullOrBool(mixed $actual, string $message = ''): void
@@ -241,7 +236,6 @@ class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * Asserts that a variable is of type int or null.
      *
-     * @param mixed  $actual
      * @param string $message
      */
     public static function assertIsNullOrInt(mixed $actual, string $message = ''): void
@@ -259,7 +253,6 @@ class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * Asserts that a variable is of type float or null.
      *
-     * @param mixed  $actual
      * @param string $message
      */
     public static function assertIsNullOrFloat(mixed $actual, string $message = ''): void
@@ -277,7 +270,6 @@ class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * Asserts that a variable is of type string or null.
      *
-     * @param mixed  $actual
      * @param string $message
      */
     public static function assertIsNullOrString(mixed $actual, string $message = ''): void


### PR DESCRIPTION
## Summary

Make the SDK installable and runnable on **PHP 8.5** while keeping 8.2 support, and finish the PHP 8.2–8.5 tooling from #21.

Closes #21. Supersedes #22 (the naive `magicsunday/xmlmapper` → `^3.0.0` bump, which broke PHP 8.2 and the annotation markers).

## The blocker

The request DTOs marked their XML mapping via **PHPDoc annotations** (`@XmlAttribute`, `@XmlNodeValue`, `@XmlCDataSection`), which only `magicsunday/xmlmapper` **1.x** reads. The 1.x line caps at `php <8.5.0`, so the SDK — and every consumer, e.g. the `universal_messenger` TYPO3 extension — could not resolve on PHP 8.5.

- `xmlmapper` **3.x** supports 8.5 but requires `php ^8.3` (drops 8.2) **and** removed annotation support (attributes only). A plain bump to `^3.0` (#22) therefore breaks both 8.2 and the SDK's markers.
- `xmlmapper` **2.0.0** supports `php ^8.2` (covering 8.2–8.5) **and** both annotation and native-attribute markers.

## Change

1. **Migrate all 41 markers to native PHP 8 attributes** (`#[XmlAttribute]` etc.) — same `MagicSunday\XmlMapper\Annotation\*` classes, now used as attributes.
2. **Require `magicsunday/xmlmapper: ^2.0 || ^3.0`** — composer resolves `2.0.0` on PHP 8.2 and `3.0.1` from 8.3 upwards.
3. **Tooling (#21):** `phpstan.neon` gets `phpVersion { min: 80200, max: 80500 }`; the CI matrix adds PHP 8.5.
4. Applied the Rector / php-cs-fixer docblock cleanups the current tool versions flag (kept in a separate commit).

## Verification

`composer ci:test` is green with **both** `xmlmapper` 2.0.0 and 3.0.1:
- phplint (50 files), PHPStan level 8 with the 8.2–8.5 `phpVersion` range (no errors), Rector, php-cs-fixer.
- The `XmlSerializer` **golden-output** test (`CreateRequestBuilderTest`, 299 assertions) stays byte-identical — proof the annotation→attribute migration is behaviour-preserving.
