### PR TITLE
chore: modernise dev tooling, drop empty phpstan baseline (#27)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,14 +50,14 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.65",
         "nyholm/psr7": "^1.8",
-        "overtrue/phplint": "^9.0",
+        "overtrue/phplint": "^9.5",
         "php-http/mock-client": "^1.6",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
-        "phpunit/phpunit": "^11.0",
+        "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
         "rector/rector": "^2.0",
         "symfony/http-client": "^7.0 || ^8.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,2 +1,0 @@
-parameters:
-	ignoreErrors: []

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,6 @@ includes:
     - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-phpunit/rules.neon
     - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-symfony/extension.neon
     - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-symfony/rules.neon
-    - %currentWorkingDirectory%/phpstan-baseline.neon
 
 services:
     -

--- a/test/Api/Actions/EventFileTest.php
+++ b/test/Api/Actions/EventFileTest.php
@@ -15,6 +15,7 @@ use Netresearch\Sdk\UniversalMessenger\Api\Actions\EventFile;
 use Netresearch\Sdk\UniversalMessenger\Exception\ServiceException;
 use Netresearch\Sdk\UniversalMessenger\Request\Event;
 use Netresearch\Sdk\UniversalMessenger\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class EventFileTest.
@@ -43,9 +44,8 @@ class EventFileTest extends TestCase
 
     /**
      * Tests "eventFile" method.
-     *
-     * @test
      */
+    #[Test]
     public function eventFile(): void
     {
         $eventFileApi = $this->getEventFileApi();

--- a/test/Api/Actions/NewsletterTest.php
+++ b/test/Api/Actions/NewsletterTest.php
@@ -21,6 +21,8 @@ use Netresearch\Sdk\UniversalMessenger\Model\NewsletterChannel;
 use Netresearch\Sdk\UniversalMessenger\Model\NewsletterStatus;
 use Netresearch\Sdk\UniversalMessenger\Test\Provider\NewsletterProvider;
 use Netresearch\Sdk\UniversalMessenger\Test\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class NewsletterTest.
@@ -66,16 +68,14 @@ class NewsletterTest extends TestCase
     /**
      * Tests "channels" method.
      *
-     * @dataProvider channelsResponseDataProvider
-     *
-     * @test
-     *
      * @param string $responseJsonFile
      *
      * @throws AuthenticationException
      * @throws DetailedServiceException
      * @throws ServiceException
      */
+    #[DataProvider('channelsResponseDataProvider')]
+    #[Test]
     public function newsletterChannels(string $responseJsonFile): void
     {
         $newsletterApi = $this->getNewsletterApi($responseJsonFile);
@@ -117,16 +117,14 @@ class NewsletterTest extends TestCase
     /**
      * Tests "status" method.
      *
-     * @dataProvider statusResponseDataProvider
-     *
-     * @test
-     *
      * @param string $responseJsonFile
      *
      * @throws AuthenticationException
      * @throws DetailedServiceException
      * @throws ServiceException
      */
+    #[DataProvider('statusResponseDataProvider')]
+    #[Test]
     public function newsletterStatus(string $responseJsonFile): void
     {
         $newsletterApi = $this->getNewsletterApi($responseJsonFile);

--- a/test/RequestBuilder/EventFile/CreateRequestBuilderTest.php
+++ b/test/RequestBuilder/EventFile/CreateRequestBuilderTest.php
@@ -16,6 +16,8 @@ use Netresearch\Sdk\UniversalMessenger\Exception\RequestValidatorException;
 use Netresearch\Sdk\UniversalMessenger\RequestBuilder\EventFile\CreateRequestBuilder;
 use Netresearch\Sdk\UniversalMessenger\Test\Provider\EventFileProvider;
 use Netresearch\Sdk\UniversalMessenger\Test\RequestBuilder\RequestBuilderTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Class CreateRequestBuilderTest.
@@ -41,15 +43,13 @@ class CreateRequestBuilderTest extends RequestBuilderTestCase
     /**
      * Tests creating a new person.
      *
-     * @dataProvider createRequestDataProvider
-     *
-     * @test
-     *
      * @param string $expectedXml
      *
      * @throws RequestValidatorException
      * @throws JsonException
      */
+    #[DataProvider('createRequestDataProvider')]
+    #[Test]
     public function create(string $expectedXml): void
     {
         $requestBuilder = new CreateRequestBuilder();


### PR DESCRIPTION
## Summary

Dev-tooling hygiene follow-up to #21 / #26. No runtime or public-API change (require-dev + phpstan config only).

- **PHPUnit**: allow 12 and 13 (`^11.0 || ^12.0 || ^13.0`); tests stay green on PHPUnit 13. `overtrue/phplint` floor raised to `^9.5`.
- **Removed `phpstan-baseline.neon`** (it only held an empty `ignoreErrors: []`) and its include — the code is clean at level 8 without it.

### jsonmapper kept at ^2.4.0 (deliberate)
jsonmapper 2.4.2 already supports PHP 8.2–8.5, so it is not a blocker. jsonmapper 3.x is **not** a clean drop-in: it deprecates `addType()` (used here for a custom `Y-m-d?H:i:s` DateTime format) and requires `php ^8.3`, which would drop PHP 8.2. Revisit when the SDK drops 8.2 and moves fully to the 3.x TypeHandler API.

Closes #27.

## Quality
`composer ci:test` green with PHPUnit 13 (lint, unit, PHPStan level 8 without baseline, Rector, php-cs-fixer).
