### PR TITLE
Security hardening: least-privilege CI token + sha256 dedup key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
     push:
     pull_request:
 
+# Least-privilege default for the GITHUB_TOKEN; the build only needs to read the repo.
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/src/RequestBuilder/EventFile/CreateRequestBuilder.php
+++ b/src/RequestBuilder/EventFile/CreateRequestBuilder.php
@@ -329,7 +329,11 @@ class CreateRequestBuilder extends AbstractRequestBuilder
             'name'        => $name,
         ];
 
-        $fileHash = md5(serialize($file));
+        // Non-cryptographic key used only to de-duplicate attachments; the hash never
+        // leaves this builder (files are consumed by value further down), so the choice of
+        // algorithm is irrelevant to the produced request. SHA-256 keeps static analysers
+        // from flagging a "weak hash" here.
+        $fileHash = hash('sha256', serialize($file));
 
         if (!in_array($fileHash, $this->data['data']['email']['files'], true)) {
             $this->data['data']['email']['files'][$fileHash] = $file;


### PR DESCRIPTION
Behebt die zwei im Security-Scan gemeldeten, im Repo-Code adressierbaren Funde (Issue #29).

## Änderungen
- **`ci: restrict GITHUB_TOKEN to contents:read`** — expliziter Least-Privilege-`permissions`-Block im CI-Workflow (CodeQL: `actions/missing-workflow-permissions`).
- **`refactor: use sha256 for the internal attachment dedup key`** — `md5(serialize($file))` => `hash('sha256', …)` (SonarCloud: `php:S4790`). Der Hash ist rein ein interner Dedup-Schlüssel für Anhänge, wird beim Request-Aufbau per `foreach (… as $file)` als **Wert** konsumiert und taucht nie im erzeugten XML auf => **verhaltensneutral**. Der Golden-XML-Test der CI bleibt byte-identisch.

## Nicht enthalten (bewusst)
- `githubactions:S8232` (auto-merge-deps.yml) betrifft einen zentral getemplateten Org-Workflow, nicht SDK-spezifisch.
- `text:S8567` (composer.lock committen) ist für eine Library ein Fehlalarm und wurde als „won't fix" dismisst.

Closes #29