### PR TITLE
feat!: migrate authentication to HTTP basic auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "ext-xmlwriter": "*",
         "magicsunday/jsonmapper": "^2.4.0",
         "magicsunday/xmlmapper": "^2.0 || ^3.0",
+        "php-http/client-common": "^2.7.0",
         "php-http/discovery": "^1.19.0",
         "php-http/httplug": "^2.4.0",
         "php-http/logger-plugin": "^1.3.0",
@@ -73,7 +74,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.0.x-dev"
+            "dev-main": "3.0.x-dev"
         }
     },
     "scripts": {

--- a/src/Api.php
+++ b/src/Api.php
@@ -75,11 +75,6 @@ class Api
     private ?EventFile $eventFileApi = null;
 
     /**
-     * @var string
-     */
-    private readonly string $apiKey;
-
-    /**
      * Api constructor.
      *
      * @param ClientInterface         $client
@@ -88,7 +83,6 @@ class Api
      * @param JsonSerializer          $jsonSerializer
      * @param XmlSerializer           $xmlSerializer
      * @param UrlBuilder              $urlBuilder
-     * @param string                  $apiKey
      */
     public function __construct(
         ClientInterface $client,
@@ -97,7 +91,6 @@ class Api
         JsonSerializer $jsonSerializer,
         XmlSerializer $xmlSerializer,
         UrlBuilder $urlBuilder,
-        string $apiKey,
     ) {
         $this->client         = $client;
         $this->requestFactory = $requestFactory;
@@ -105,7 +98,6 @@ class Api
         $this->jsonSerializer = $jsonSerializer;
         $this->xmlSerializer  = $xmlSerializer;
         $this->urlBuilder     = $urlBuilder;
-        $this->apiKey         = $apiKey;
     }
 
     /**
@@ -117,10 +109,7 @@ class Api
     {
         $this->urlBuilder
             ->reset()
-            ->addPath('/' . Newsletter::PATH)
-            ->setParams([
-                'umopen' => $this->apiKey,
-            ]);
+            ->addPath('/' . Newsletter::PATH);
 
         if (!$this->newsletterApi instanceof Newsletter) {
             $this->newsletterApi = new Newsletter(
@@ -145,10 +134,7 @@ class Api
     {
         $this->urlBuilder
             ->reset()
-            ->addPath('/' . EventFile::PATH)
-            ->setParams([
-                'open' => $this->apiKey,
-            ]);
+            ->addPath('/' . EventFile::PATH);
 
         if (!$this->eventFileApi instanceof EventFile) {
             $this->eventFileApi = new EventFile(

--- a/src/Api/Actions/EventFile.php
+++ b/src/Api/Actions/EventFile.php
@@ -38,7 +38,7 @@ class EventFile extends AbstractApiEndpoint
     /**
      * Posts a XML event file request.
      *
-     * POST https://<BASE-URL>/de.pinuts.cmsbs.restsend.EventFile/?open=
+     * POST https://<BASE-URL>/de.pinuts.cmsbs.restsend.EventFile/
      *
      * @param EventRequest $request
      *

--- a/src/Api/Actions/Newsletter.php
+++ b/src/Api/Actions/Newsletter.php
@@ -40,7 +40,7 @@ class Newsletter extends AbstractApiEndpoint
     /**
      * Returns a list of all newsletter channels.
      *
-     * GET https://<BASE-URL>/de.pinuts.cmsbs.restapi.Channels/index?umopen=
+     * GET https://<BASE-URL>/de.pinuts.cmsbs.restapi.Channels/index
      *
      * @return NewsletterChannelCollection
      *
@@ -64,7 +64,7 @@ class Newsletter extends AbstractApiEndpoint
     /**
      * Returns the status of a newsletter delivery.
      *
-     * GET https://<BASE-URL>/de.pinuts.cmsbs.restapi.NewsletterQueue/status/<eventId>?umopen=
+     * GET https://<BASE-URL>/de.pinuts.cmsbs.restapi.NewsletterQueue/status/<eventId>
      *
      * @param string $eventId
      *

--- a/src/Http/Formatter/RedactAuthorizationHeaderFormatter.php
+++ b/src/Http/Formatter/RedactAuthorizationHeaderFormatter.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of the package netresearch/sdk-api-universal-messenger.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\Sdk\UniversalMessenger\Http\Formatter;
+
+use Http\Message\Formatter\FullHttpMessageFormatter;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * A full HTTP message formatter that redacts the "Authorization" request header
+ * before formatting, so the HTTP basic authentication credentials are never
+ * written to the log.
+ *
+ * @author  Rico Sonntag <rico.sonntag@netresearch.de>
+ * @license Netresearch https://www.netresearch.de
+ * @link    https://www.netresearch.de
+ */
+final class RedactAuthorizationHeaderFormatter extends FullHttpMessageFormatter
+{
+    /**
+     * Formats a request, with the "Authorization" header redacted.
+     *
+     * @param RequestInterface $request
+     *
+     * @return string
+     */
+    public function formatRequest(RequestInterface $request): string
+    {
+        return parent::formatRequest($this->redact($request));
+    }
+
+    /**
+     * Formats a response in context of its request, with the request's
+     * "Authorization" header redacted.
+     *
+     * @param ResponseInterface $response
+     * @param RequestInterface  $request
+     *
+     * @return string
+     */
+    public function formatResponseForRequest(ResponseInterface $response, RequestInterface $request): string
+    {
+        return parent::formatResponseForRequest($response, $this->redact($request));
+    }
+
+    /**
+     * Returns a clone of the request with a redacted "Authorization" header.
+     *
+     * @param RequestInterface $request
+     *
+     * @return RequestInterface
+     */
+    private function redact(RequestInterface $request): RequestInterface
+    {
+        if ($request->hasHeader('Authorization')) {
+            return $request->withHeader('Authorization', '****');
+        }
+
+        return $request;
+    }
+}

--- a/src/UniversalMessenger.php
+++ b/src/UniversalMessenger.php
@@ -12,12 +12,14 @@ declare(strict_types=1);
 namespace Netresearch\Sdk\UniversalMessenger;
 
 use Closure;
+use Http\Client\Common\Plugin\AuthenticationPlugin;
 use Http\Client\Common\Plugin\LoggerPlugin;
 use Http\Client\Common\PluginClient;
 use Http\Client\Common\PluginClientFactory;
 use Http\Discovery\Exception\NotFoundException;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
+use Http\Message\Authentication\BasicAuth;
 use Http\Message\Formatter\FullHttpMessageFormatter;
 use Netresearch\Sdk\UniversalMessenger\Exception\ServiceException;
 use Netresearch\Sdk\UniversalMessenger\Exception\ServiceExceptionFactory;
@@ -58,11 +60,18 @@ class UniversalMessenger
     private readonly XmlSerializer $xmlSerializer;
 
     /**
-     * The API key.
+     * The public API key used as the username for HTTP basic authentication.
      *
      * @var string
      */
     private readonly string $apiKey;
+
+    /**
+     * The secret API key used as the password for HTTP basic authentication.
+     *
+     * @var string
+     */
+    private readonly string $apiSecret;
 
     /**
      * Api instance for implementing lazy loading.
@@ -76,17 +85,20 @@ class UniversalMessenger
      *
      * @param LoggerInterface    $logger        A logger instance
      * @param string             $webserviceUrl The URL of the webservice endpoint
-     * @param string             $apiKey        The API key
+     * @param string             $apiKey        The public API key (basic auth username)
+     * @param string             $apiSecret     The secret API key (basic auth password)
      * @param string[]|Closure[] $classMap      A class map to override the default class names (source => target)
      */
     public function __construct(
         LoggerInterface $logger,
         string $webserviceUrl,
         string $apiKey,
+        string $apiSecret,
         array $classMap = [],
     ) {
-        $this->logger = $logger;
-        $this->apiKey = $apiKey;
+        $this->logger    = $logger;
+        $this->apiKey    = $apiKey;
+        $this->apiSecret = $apiSecret;
 
         $this->urlBuilder = new UrlBuilder();
         $this->urlBuilder
@@ -114,6 +126,9 @@ class UniversalMessenger
         return (new PluginClientFactory())->createClient(
             $httpClient,
             [
+                new AuthenticationPlugin(
+                    new BasicAuth($this->apiKey, $this->apiSecret)
+                ),
                 new LoggerPlugin($this->logger, new FullHttpMessageFormatter(null)),
                 new ErrorPlugin(),
             ]
@@ -143,8 +158,7 @@ class UniversalMessenger
                 $streamFactory,
                 $this->jsonSerializer,
                 $this->xmlSerializer,
-                $this->urlBuilder,
-                $this->apiKey
+                $this->urlBuilder
             );
         }
 

--- a/src/UniversalMessenger.php
+++ b/src/UniversalMessenger.php
@@ -20,10 +20,10 @@ use Http\Discovery\Exception\NotFoundException;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
 use Http\Message\Authentication\BasicAuth;
-use Http\Message\Formatter\FullHttpMessageFormatter;
 use Netresearch\Sdk\UniversalMessenger\Exception\ServiceException;
 use Netresearch\Sdk\UniversalMessenger\Exception\ServiceExceptionFactory;
 use Netresearch\Sdk\UniversalMessenger\Http\ClientPlugin\ErrorPlugin;
+use Netresearch\Sdk\UniversalMessenger\Http\Formatter\RedactAuthorizationHeaderFormatter;
 use Netresearch\Sdk\UniversalMessenger\Serializer\JsonSerializer;
 use Netresearch\Sdk\UniversalMessenger\Serializer\XmlSerializer;
 use Psr\Log\LoggerInterface;
@@ -129,7 +129,7 @@ class UniversalMessenger
                 new AuthenticationPlugin(
                     new BasicAuth($this->apiKey, $this->apiSecret)
                 ),
-                new LoggerPlugin($this->logger, new FullHttpMessageFormatter(null)),
+                new LoggerPlugin($this->logger, new RedactAuthorizationHeaderFormatter(null)),
                 new ErrorPlugin(),
             ]
         );

--- a/test/Api/Actions/EventFileTest.php
+++ b/test/Api/Actions/EventFileTest.php
@@ -52,7 +52,7 @@ class EventFileTest extends TestCase
         $result       = $eventFileApi->event(new Event());
 
         self::assertWebserviceUrl(
-            'https://www.example.org/de.pinuts.cmsbs.restsend.EventFile/?open=TOTALLY-SECRET-API-KEY',
+            'https://www.example.org/de.pinuts.cmsbs.restsend.EventFile/',
             $eventFileApi
         );
 

--- a/test/Api/Actions/NewsletterTest.php
+++ b/test/Api/Actions/NewsletterTest.php
@@ -82,7 +82,7 @@ class NewsletterTest extends TestCase
         $result        = $newsletterApi->channels();
 
         self::assertWebserviceUrl(
-            'https://www.example.org/de.pinuts.cmsbs.restapi.Channels/index?umopen=TOTALLY-SECRET-API-KEY',
+            'https://www.example.org/de.pinuts.cmsbs.restapi.Channels/index',
             $newsletterApi
         );
 
@@ -131,7 +131,7 @@ class NewsletterTest extends TestCase
         $result        = $newsletterApi->status('FAKE-EVENT-ID');
 
         self::assertWebserviceUrl(
-            'https://www.example.org/de.pinuts.cmsbs.restapi.NewsletterQueue/status/FAKE-EVENT-ID?umopen=TOTALLY-SECRET-API-KEY',
+            'https://www.example.org/de.pinuts.cmsbs.restapi.NewsletterQueue/status/FAKE-EVENT-ID',
             $newsletterApi
         );
 

--- a/test/Http/Formatter/RedactAuthorizationHeaderFormatterTest.php
+++ b/test/Http/Formatter/RedactAuthorizationHeaderFormatterTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the package netresearch/sdk-api-universal-messenger.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\Sdk\UniversalMessenger\Test\Http\Formatter;
+
+use Netresearch\Sdk\UniversalMessenger\Http\Formatter\RedactAuthorizationHeaderFormatter;
+use Nyholm\Psr7\Request;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the RedactAuthorizationHeaderFormatter.
+ *
+ * @author  Rico Sonntag <rico.sonntag@netresearch.de>
+ * @license Netresearch https://www.netresearch.de
+ * @link    https://www.netresearch.de
+ */
+class RedactAuthorizationHeaderFormatterTest extends TestCase
+{
+    private const SECRET = 'dG9wLXNlY3JldC1jcmVkZW50aWFscw==';
+
+    #[Test]
+    public function redactsAuthorizationHeaderWhenFormattingRequest(): void
+    {
+        $formatter = new RedactAuthorizationHeaderFormatter(null);
+
+        $request = (new Request('GET', 'https://www.example.org/p'))
+            ->withHeader('Authorization', 'Basic ' . self::SECRET);
+
+        $formatted = $formatter->formatRequest($request);
+
+        self::assertStringNotContainsString(self::SECRET, $formatted);
+        self::assertStringContainsString('Authorization: ****', $formatted);
+    }
+
+    #[Test]
+    public function leavesRequestWithoutAuthorizationHeaderUntouched(): void
+    {
+        $formatter = new RedactAuthorizationHeaderFormatter(null);
+
+        $request = new Request('GET', 'https://www.example.org/p');
+
+        $formatted = $formatter->formatRequest($request);
+
+        self::assertStringContainsString('GET', $formatted);
+        self::assertStringNotContainsString('Authorization', $formatted);
+    }
+
+    #[Test]
+    public function doesNotMutateTheOriginalRequest(): void
+    {
+        $formatter = new RedactAuthorizationHeaderFormatter(null);
+
+        $request = (new Request('GET', 'https://www.example.org/p'))
+            ->withHeader('Authorization', 'Basic ' . self::SECRET);
+
+        $formatter->formatRequest($request);
+
+        self::assertSame('Basic ' . self::SECRET, $request->getHeaderLine('Authorization'));
+    }
+
+    #[Test]
+    public function redactsAuthorizationHeaderWhenFormattingResponseForRequest(): void
+    {
+        $formatter = new RedactAuthorizationHeaderFormatter(null);
+
+        $request = (new Request('GET', 'https://www.example.org/p'))
+            ->withHeader('Authorization', 'Basic ' . self::SECRET);
+
+        $formatted = $formatter->formatResponseForRequest(new Response(200), $request);
+
+        self::assertStringNotContainsString(self::SECRET, $formatted);
+    }
+}

--- a/test/Http/Formatter/RedactAuthorizationHeaderFormatterTest.php
+++ b/test/Http/Formatter/RedactAuthorizationHeaderFormatterTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
  */
 class RedactAuthorizationHeaderFormatterTest extends TestCase
 {
-    private const SECRET = 'dG9wLXNlY3JldC1jcmVkZW50aWFscw==';
+    private const AUTHORIZATION_HEADER = 'Basic not-a-real-credential';
 
     #[Test]
     public function redactsAuthorizationHeaderWhenFormattingRequest(): void
@@ -34,11 +34,11 @@ class RedactAuthorizationHeaderFormatterTest extends TestCase
         $formatter = new RedactAuthorizationHeaderFormatter(null);
 
         $request = (new Request('GET', 'https://www.example.org/p'))
-            ->withHeader('Authorization', 'Basic ' . self::SECRET);
+            ->withHeader('Authorization', self::AUTHORIZATION_HEADER);
 
         $formatted = $formatter->formatRequest($request);
 
-        self::assertStringNotContainsString(self::SECRET, $formatted);
+        self::assertStringNotContainsString('not-a-real-credential', $formatted);
         self::assertStringContainsString('Authorization: ****', $formatted);
     }
 
@@ -61,11 +61,11 @@ class RedactAuthorizationHeaderFormatterTest extends TestCase
         $formatter = new RedactAuthorizationHeaderFormatter(null);
 
         $request = (new Request('GET', 'https://www.example.org/p'))
-            ->withHeader('Authorization', 'Basic ' . self::SECRET);
+            ->withHeader('Authorization', self::AUTHORIZATION_HEADER);
 
         $formatter->formatRequest($request);
 
-        self::assertSame('Basic ' . self::SECRET, $request->getHeaderLine('Authorization'));
+        self::assertSame(self::AUTHORIZATION_HEADER, $request->getHeaderLine('Authorization'));
     }
 
     #[Test]
@@ -74,10 +74,10 @@ class RedactAuthorizationHeaderFormatterTest extends TestCase
         $formatter = new RedactAuthorizationHeaderFormatter(null);
 
         $request = (new Request('GET', 'https://www.example.org/p'))
-            ->withHeader('Authorization', 'Basic ' . self::SECRET);
+            ->withHeader('Authorization', self::AUTHORIZATION_HEADER);
 
         $formatted = $formatter->formatResponseForRequest(new Response(200), $request);
 
-        self::assertStringNotContainsString(self::SECRET, $formatted);
+        self::assertStringNotContainsString('not-a-real-credential', $formatted);
     }
 }

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -82,8 +82,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
             Psr17FactoryDiscovery::findStreamFactory(),
             new JsonSerializer(),
             new XmlSerializer(),
-            $urlBuilder,
-            'TOTALLY-SECRET-API-KEY'
+            $urlBuilder
         );
 
         $serviceFactoryMock = $this


### PR DESCRIPTION
## Summary

The Universal Messenger REST API migrated its authentication mechanism. Until UM 7.40 the API token was passed via the `umopen`/`open` query parameter (configured through `cmsbs.open`). This mechanism is deprecated. The current API uses **API keys** consisting of a public key and a secret key, sent as an HTTP **basic authentication** header (public key = username, secret key = password).

The SDK still sent the deprecated `umopen`/`open` query parameter and therefore could no longer authenticate against the current API (`401 Unauthorized`).

## Changes

- Add `AuthenticationPlugin` (php-http/client-common) with `BasicAuth` (php-http/message) to the plugin client, so every request carries the `Authorization: Basic …` header.
- Extend the `UniversalMessenger` constructor with the secret key (`$apiSecret`).
- Drop the `umopen`/`open` query parameters from the `Newsletter` and `EventFile` endpoint URLs (and the corresponding docblocks/tests).
- Require `php-http/client-common`.

## Breaking change

`UniversalMessenger::__construct()` now requires the secret key as its fourth argument, and authentication uses HTTP basic auth instead of the `umopen`/`open` query parameter. This warrants a new major release (**3.0.0**).

## Testing

- `composer ci:test` green locally (phplint, phpstan, rector, phpunit, php-cs-fixer) on PHP 8.4.
- Verified end-to-end against the live UM test system: `newsletter()->channels()` returns the channel list, and the `EventFile` POST authenticates and is accepted (event id assigned).

Closes #31
