### PR TITLE
docs: document basic auth and API compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,16 @@ The SDK currently implements only the endpoints and data structures that were re
 - [Basic usage & Limitations](doc/Basic.md)
 - [Endpoints](doc/Endpoints.md)
 - [Error handling](doc/ErrorHandling.md)
+
+## Compatibility
+The Universal Messenger REST API is not versioned on the client side. The SDK addresses fixed endpoints,
+and the behaviour — most notably the authentication scheme — depends on the Universal Messenger server
+version that is deployed. Authentication is therefore what distinguishes the server generations, and the
+SDK major version reflects the supported era:
+
+| SDK      | Authentication                                                     | Universal Messenger server |
+|:---------|:-------------------------------------------------------------------|:---------------------------|
+| `^2.0`   | API token via the `umopen`/`open` query parameter (`cmsbs.open`)   | up to UM 7.40              |
+| `^3.0`   | API key (public key + secret) via HTTP basic authentication        | UM after 7.40              |
+
+Pin the SDK major version to match your Universal Messenger server.

--- a/doc/Basic.md
+++ b/doc/Basic.md
@@ -4,23 +4,27 @@ builders to create a valid request object. This allows you the using of the SDK 
 underlying API. Use the request object together with the desired API endpoint method to call the interface.
 
 ## Create an API instance
-But first of all you need to create a new API instance. You pass the base API URL to be called and the API key
-to this instance.
+First of all you need to create a new API instance. You pass the base API URL together with the API key
+and secret to this instance.
 
 ```php
 // Create API client instance
 $apiClient = new \Netresearch\Sdk\UniversalMessenger\UniversalMessenger(
     new \Psr\Log\NullLogger(),
     '<API-BASE-URL>',
-    '<API-KEY>'
+    '<API-KEY>',
+    '<API-SECRET>'
 );
 ```
+
+The API uses HTTP basic authentication: the public API key is sent as the username and the secret key as
+the password. Create an API key in the Universal Messenger backend to obtain both values.
 
 The client instance provides the `api()` method to access the implemented API endpoints.
 
 
 ## Class map
-Optionally, an additional class map can be passed to the constructor of the API client as the fourth parameter.
+Optionally, an additional class map can be passed to the constructor of the API client as the fifth parameter.
 By default, the JSON response from the API is mapped to the appropriate models in the SDK. By passing an alternative
 mapping, the returned class structure can be adapted to the needs. The class to be overwritten in the SDK is
 specified as the key, and the name of the new class is expected as the value.
@@ -36,6 +40,7 @@ $apiClient = new \Netresearch\Sdk\UniversalMessenger\UniversalMessenger(
     new \Psr\Log\NullLogger(),
     '<API-BASE-URL>',
     '<API-KEY>',
+    '<API-SECRET>',
     $classMap
 );
 ```

--- a/doc/Basic.md
+++ b/doc/Basic.md
@@ -4,8 +4,8 @@ builders to create a valid request object. This allows you the using of the SDK 
 underlying API. Use the request object together with the desired API endpoint method to call the interface.
 
 ## Create an API instance
-First of all you need to create a new API instance. You pass the base API URL together with the API key
-and secret to this instance.
+First of all you need to create a new API instance. You pass a PSR-3 logger, the base API URL and the
+API key and secret to this instance.
 
 ```php
 // Create API client instance


### PR DESCRIPTION
Follow-up to #32.

Fixes the developer documentation that became incorrect after the basic-auth migration and documents how API compatibility works.

- `doc/Basic.md`: add the `$apiSecret` argument to the constructor example (it is now the fourth argument) and move the class map to the fifth position; explain HTTP basic auth (public key = username, secret = password).
- `README.md`: add a **Compatibility** table mapping the SDK major version to the Universal Messenger server generation (`^2.0` = `umopen` token up to UM 7.40, `^3.0` = API-key basic auth afterwards) and note that the API is not versioned client-side.

Closes #33