### PR TITLE
ci: migrate to org php-ci shared reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,15 @@ on:
     push:
     pull_request:
 
-# Least-privilege default for the GITHUB_TOKEN; the reusable's job declares
-# its own `contents: read`, so the caller needs nothing at the top level.
+# Least-privilege default for the GITHUB_TOKEN; the calling job grants the
+# `contents: read` the reusable requires (a reusable cannot obtain a
+# permission the caller did not grant — otherwise the run startup-fails).
 permissions: {}
 
 jobs:
     php-ci:
+        permissions:
+            contents: read
         uses: netresearch/.github/.github/workflows/php-ci.yml@main
         with:
             php-versions: '["8.2", "8.3", "8.4", "8.5"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,11 @@ jobs:
         with:
             php-versions: '["8.2", "8.3", "8.4", "8.5"]'
             extensions: "mbstring, intl, json, simplexml, xmlwriter"
-            composer-validate: true
+            # composer validate --strict rejects this library's intentional
+            # unbound `*` constraints for the virtual psr/http-*-implementation
+            # packages; run non-strict validate before install instead.
+            composer-validate: false
+            pre-install-cmd: "composer validate"
             run-phpstan: true
             phpstan-cmd: "composer ci:test:php:phpstan -- --error-format=github"
             run-rector: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,82 +4,25 @@ on:
     push:
     pull_request:
 
-# Least-privilege default for the GITHUB_TOKEN; the build only needs to read the repo.
-permissions:
-    contents: read
+# Least-privilege default for the GITHUB_TOKEN; the reusable's job declares
+# its own `contents: read`, so the caller needs nothing at the top level.
+permissions: {}
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-
-        strategy:
-            fail-fast: false
-            matrix:
-                php: [ '8.2', '8.3', '8.4', '8.5' ]
-
-        steps:
-            -   id: checkout
-                name: Checkout
-                uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-            -   id: setup_php
-                name: Set up PHP version ${{ matrix.php }}
-                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
-                with:
-                    php-version: ${{ matrix.php }}
-                    tools: composer:v2, php-cs-fixer
-
-            -   name: Validate composer.json and composer.lock
-                run: composer validate
-
-            -   id: composer-cache-vars
-                name: Composer Cache Vars
-                run: |
-                    echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-                    echo "timestamp=$(date +"%s")" >> $GITHUB_OUTPUT
-
-            -   id: composer-cache-dependencies
-                name: Cache Composer dependencies
-                uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-                with:
-                    path: ${{ steps.composer-cache-vars.outputs.dir }}
-                    key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ steps.composer-cache-vars.outputs.timestamp }}
-                    restore-keys: |
-                        ${{ runner.os }}-composer-${{ matrix.php }}-
-                        ${{ runner.os }}-composer-
-
-            -   id: install
-                name: Install dependencies
-                run: |
-                    composer validate
-                    composer install --no-progress
-
-            -   id: lint
-                name: Lint
-                if: ${{ always() && steps.install.conclusion == 'success' }}
-                run: |
-                    composer ci:test:php:lint
-
-            -   id: cgl
-                name: CGL
-                if: ${{ always() && steps.install.conclusion == 'success' }}
-                run: |
-                    composer ci:cgl -- --dry-run
-
-            -   id: phpstan
-                name: PHPStan
-                if: ${{ always() && steps.install.conclusion == 'success' }}
-                run: |
-                    composer ci:test:php:phpstan -- --error-format=github
-
-            -   id: rector
-                name: Rector
-                if: ${{ always() && steps.install.conclusion == 'success' }}
-                run: |
-                    composer ci:test:php:rector
-
-            -   id: tests_unit
-                name: Unit Tests
-                if: ${{ always() && steps.install.conclusion == 'success' }}
-                run: |
-                    composer ci:test:php:unit
+    php-ci:
+        uses: netresearch/.github/.github/workflows/php-ci.yml@main
+        with:
+            php-versions: '["8.2", "8.3", "8.4", "8.5"]'
+            extensions: "mbstring, intl, json, simplexml, xmlwriter"
+            composer-validate: true
+            run-phpstan: true
+            phpstan-cmd: "composer ci:test:php:phpstan -- --error-format=github"
+            run-rector: true
+            rector-cmd: "composer ci:test:php:rector"
+            run-phpunit: true
+            phpunit-cmd: "composer ci:test:php:unit"
+            # The reusable has no dedicated PHP-lint (phplint) toggle, so the
+            # phplint syntax check is folded in ahead of the PHP-CS-Fixer
+            # dry-run under the single "PHP-CS-Fixer" step.
+            run-cs-fixer: true
+            cs-fixer-cmd: "composer ci:test:php:lint && composer ci:test:php:cgl"


### PR DESCRIPTION
## What
Migrate CI to the org-owned **`netresearch/.github` `php-ci.yml@main`** reusable — the repo had a fully inline workflow (checkout + `shivammathur/setup-php` + `actions/cache` + composer + phpunit/phpstan/cs-fixer). It now calls the central reusable, so third-party actions live only there (easier maintenance).

Inputs mirror the repo's existing PHP-version matrix and composer scripts. `@main` is intentional (NR-owned reusable — never SHA-pinned).

## Verification
`actionlint` clean; every `with:`/`secrets:` value is a declared `php-ci.yml` input/secret.
