### PR TITLE
chore(renovate): stop digest-pinning org-owned reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     php-ci:
         permissions:
             contents: read
-        uses: netresearch/.github/.github/workflows/php-ci.yml@c17280ddc8e7b4392fd570c771dfd0835a5e3870 # main
+        uses: netresearch/.github/.github/workflows/php-ci.yml@main
         with:
             php-versions: '["8.2", "8.3", "8.4", "8.5"]'
             extensions: "mbstring, intl, json, simplexml, xmlwriter"

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,14 @@
     ":automergeMinor",
     ":automergePatch"
   ],
+  "packageRules": [
+    {
+      "description": "Do not pin org-internal reusable workflows (use @main)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["netresearch/**"],
+      "pinDigests": false
+    }
+  ],
   "automerge": true,
   "automergeType": "pr",
   "platformAutomerge": true


### PR DESCRIPTION
## Problem

Renovate auto-merged [#38](https://github.com/netresearch/sdk-api-universal-messenger/pull/38), which rewrote the `netresearch/.github` php-ci reusable-workflow ref from `@main` to a commit SHA (`5f7fe51…`). Org-owned resources are tracked by branch, not digest-pinned.

Cause: `renovate.json` extends `helpers:pinGitHubActionDigests` with no exemption, and `automerge` + `platformAutomerge` merged the pin without review.

## Change

- **`renovate.json`**: add a `packageRule` exempting `netresearch/**` from `pinDigests` (external third-party actions stay pinned — that exemption is org-scoped only). Mirrors the pattern already in [netresearch/pagerangers-skill](https://github.com/netresearch/pagerangers-skill/blob/main/renovate.json).
- **`.github/workflows/ci.yml`**: revert `php-ci.yml@5f7fe51…` → `@main`.

Because Renovate applies the last matching `packageRule`, and this repo extends the pin preset after the shared org config, the exemption must live in this repo's own `packageRules` (a shared-config rule would be overridden).